### PR TITLE
fix: correctly remove files

### DIFF
--- a/.changeset/purple-seals-help.md
+++ b/.changeset/purple-seals-help.md
@@ -1,0 +1,5 @@
+---
+'create-boilertowns': patch
+---
+
+Fix `cleanupFiles` function.

--- a/src/modifiers/cleanupFiles.ts
+++ b/src/modifiers/cleanupFiles.ts
@@ -16,13 +16,11 @@ export const cleanupFiles = (dir: string) => {
 	for (const file of TO_BE_REMOVED) {
 		const target = path.join(dir, file);
 
-		if (!fs.existsSync(target)) {
-			return;
+		if (fs.existsSync(target)) {
+			fs.rmSync(target, {
+				force: true,
+				recursive: true,
+			});
 		}
-
-		fs.rmSync(target, {
-			force: true,
-			recursive: true,
-		});
 	}
 };


### PR DESCRIPTION
<!-- Thank you for opening a pull request to Boilertowns 🙏 -->

## Summary

Wrongly return statement makes `cleanupFiles` exit sooner and not finish the loop.